### PR TITLE
feature: favourite news and read later

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# Copilot Instructions for Jetpack Compose Android Project
+
+This document outlines key considerations when using Copilot for this Jetpack Compose project.
+
+## General Guidelines
+
+* **OpenJDK 21:** Ensure the project is set to use openjdk version "21.0.7" for compatibility with the latest Compose features.
+* **Context is Key:** Provide surrounding `@Composable` functions, state declarations, and relevant data models for accurate suggestions.
+* **Prioritize Kotlin Idioms:** When writing Kotlin, favor modern idiomatic expressions and features.
+* **Prioritize Compose Idioms:** Favor declarative UI, unidirectional data flow, and the use of `State`, `MutableState`, `remember`, `rememberSaveable`, `ViewModel`, and `Flow`.
+* **Modularity & Reusability:** Encourage small, focused, and reusable `@Composable` functions. Think components.
+* **Performance Awareness:** Avoid unnecessary recompositions. Utilize `key`s in `LazyColumn`/`LazyRow` and `derivedStateOf` where appropriate.
+* **Resource Management:** Be mindful of string, dimension, color, and drawable resources. Encourage referencing existing resources where appropriate.
+
+### Kotlin Code
+
+* **AndroidX Libraries:** Prefer AndroidX libraries over legacy support libraries.
+* **Lifecycle Awareness:** Generate code that respects Android lifecycles (e.g., `ViewModel`, `LifecycleOwner`).
+* **Coroutines/Flow:** For asynchronous operations, prioritize Kotlin Coroutines and Flow over older callback-based patterns.
+* **Dependency Injection:** If using a DI framework (e.g., Hilt, Koin), ensure generated code integrates correctly.
+
+### Composable Functions
+
+* **State Management:**
+    * For UI-specific state within a composable, use `remember { mutableStateOf(...) }`.
+    * For state that needs to survive configuration changes, use `rememberSaveable { mutableStateOf(...) }`.
+    * For screen-level UI state, use `ViewModel` and expose `StateFlow` or `LiveData` (converted to `State` with `collectAsState`/`observeAsState`).
+    * Pass state *down* and events *up* (unidirectional data flow).
+* **Modifiers:** Apply modifiers thoughtfully, often to the top-most layout composable. Chain them logically.
+* **Material Design 3:** Adhere to Material Design 3 guidelines for consistent UI, including `MaterialTheme` for colors, typography, and shapes.
+* **Layouts:** Prefer `Column`, `Row`, `Box`, `ConstraintLayout`, `LazyColumn`, `LazyRow`, and `LazyVerticalGrid` for structuring UI.
+* **Animations:** Suggest using built-in Compose animation APIs like `animate*AsState`, `Transition`, and `AnimatedVisibility`.
+
+### Data Flow & Architecture
+
+* **Separation of Concerns:** Keep UI logic within composables and business logic in ViewModels or domain layers.
+* **Immutability:** Prefer immutable data classes for UI state to ensure correctness and optimize recomposition.
+
+### Build System (Gradle)
+
+* **Dependencies:** Suggest up-to-date and stable versions of libraries.
+* **Build Features:** Be aware of build features like `viewBinding`, `dataBinding`, and `compose`.
+
+### Testing
+
+* **Unit Tests:** Focus on isolated unit tests for business logic.
+* **Instrumentation Tests:** Consider basic UI interactions and integration.
+* **Composable Tests:** Generate tests using `ComposeTestRule` to verify UI behavior and appearance.
+* **Semantics Tree:** Understand that Compose tests interact with the semantics tree.
+
+---
+
+**Note:** Always review Copilot's suggestions carefully and ensure they align with Android best practices and project architecture.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -28,11 +29,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "21"
     }
     buildFeatures {
         compose = true
@@ -60,6 +61,11 @@ dependencies {
     // Networking with Retrofit
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
+
+    // Room Database
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
             android:name=".AboutActivity"
             android:exported="false" />
         <activity
+            android:name=".FavouritesActivity"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".HackerFeedApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
@@ -50,13 +50,16 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vpk.hackerfeed.database.FavouriteArticle
+import com.vpk.hackerfeed.di.ViewModelFactory
 import com.vpk.hackerfeed.ui.theme.GithubDarkGray
 import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
 import com.vpk.hackerfeed.ui.theme.getCardBackgroundColor
 import com.vpk.hackerfeed.components.AnimatedFavoriteButton
 
 class FavouritesActivity : ComponentActivity() {
-    private val viewModel: FavouritesViewModel by viewModels()
+    private val viewModel: FavouritesViewModel by viewModels {
+        ViewModelFactory((application as HackerFeedApplication).container)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -51,6 +52,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vpk.hackerfeed.database.FavouriteArticle
 import com.vpk.hackerfeed.ui.theme.GithubDarkGray
 import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
+import com.vpk.hackerfeed.components.AnimatedFavoriteButton
 
 class FavouritesActivity : ComponentActivity() {
     private val viewModel: FavouritesViewModel by viewModels()
@@ -244,16 +246,11 @@ fun FavouriteArticleCard(
                             color = MaterialTheme.colorScheme.secondary
                         )
                     }
-                    IconButton(
+                    AnimatedFavoriteButton(
+                        isFavourite = true, // Always true in favourites screen
                         onClick = onRemoveFavourite,
                         modifier = Modifier.padding(start = 8.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Favorite,
-                            contentDescription = stringResource(R.string.remove_from_favourites),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
+                    )
                 }
                 if (article.url != null) {
                     Button(

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
@@ -1,0 +1,349 @@
+package com.vpk.hackerfeed
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vpk.hackerfeed.database.FavouriteArticle
+import com.vpk.hackerfeed.ui.theme.GithubDarkGray
+import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
+
+class FavouritesActivity : ComponentActivity() {
+    private val viewModel: FavouritesViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            HackerFeedTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    FavouritesScreen(viewModel = viewModel)
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FavouritesScreen(viewModel: FavouritesViewModel) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isDarkTheme = isSystemInDarkTheme()
+    val localContext = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = stringResource(R.string.favourites_title))
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        if (localContext is ComponentActivity) {
+                            localContext.finish()
+                        }
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.navigate_back_content_desc)
+                        )
+                    }
+                },
+                colors = if (isDarkTheme) {
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = GithubDarkGray,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        actionIconContentColor = MaterialTheme.colorScheme.onSurface,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurface
+                    )
+                } else {
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                        actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator()
+            } else if (uiState.error != null) {
+                Text(
+                    text = uiState.error!!,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else if (uiState.favouriteArticles.isEmpty()) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Favorite,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.no_favourites),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.no_favourites_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                FavouritesList(
+                    favourites = uiState.favouriteArticles,
+                    onRemoveFavourite = { articleId -> viewModel.removeFromFavourites(articleId) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FavouritesList(
+    favourites: List<FavouriteArticle>,
+    onRemoveFavourite: (Long) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 8.dp)
+    ) {
+        items(
+            items = favourites,
+            key = { favourite -> favourite.id }
+        ) { favourite ->
+            FavouriteArticleCard(
+                article = favourite,
+                onRemoveFavourite = { onRemoveFavourite(favourite.id) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun FavouriteArticleCard(
+    article: FavouriteArticle,
+    onRemoveFavourite: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    // Determine the card background color based on the current theme (dark/light)
+    val cardBackgroundColor = if (isSystemInDarkTheme()) {
+        com.vpk.hackerfeed.ui.theme.GithubCardBackgroundDark
+    } else {
+        com.vpk.hackerfeed.ui.theme.GithubCardBackgroundLight
+    }
+    val cardContentColor = MaterialTheme.colorScheme.onSurface
+
+    Card(
+        modifier = modifier.padding(horizontal = 16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = cardBackgroundColor,
+            contentColor = cardContentColor
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = article.title ?: stringResource(R.string.no_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "by ${article.author ?: stringResource(R.string.unknown)}",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(R.string.points, article.score ?: 0),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
+                    IconButton(
+                        onClick = onRemoveFavourite,
+                        modifier = Modifier.padding(start = 8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Favorite,
+                            contentDescription = stringResource(R.string.remove_from_favourites),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+                if (article.url != null) {
+                    Button(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_VIEW, article.url.toUri())
+                            context.startActivity(intent)
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        ),
+                        contentPadding = PaddingValues(vertical = 8.dp)
+                    ) {
+                        Text(stringResource(R.string.read_full_article))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FavouritesScreenPreview() {
+    HackerFeedTheme {
+        val previewFavourites = listOf(
+            FavouriteArticle(
+                id = 1,
+                title = "Amazing Kotlin Features You Should Know",
+                author = "dev.kotlin",
+                score = 256,
+                time = 0,
+                url = "https://example.com/1"
+            ),
+            FavouriteArticle(
+                id = 2,
+                title = "Building Android Apps with Jetpack Compose",
+                author = "android.dev",
+                score = 189,
+                time = 0,
+                url = "https://example.com/2"
+            )
+        )
+        
+        Surface {
+            FavouritesList(
+                favourites = previewFavourites,
+                onRemoveFavourite = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Empty Favourites State")
+@Composable
+fun EmptyFavouritesStatePreview() {
+    HackerFeedTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Favorite,
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp),
+                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.no_favourites),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.no_favourites_description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
@@ -52,6 +52,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vpk.hackerfeed.database.FavouriteArticle
 import com.vpk.hackerfeed.ui.theme.GithubDarkGray
 import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
+import com.vpk.hackerfeed.ui.theme.getCardBackgroundColor
 import com.vpk.hackerfeed.components.AnimatedFavoriteButton
 
 class FavouritesActivity : ComponentActivity() {
@@ -196,12 +197,8 @@ fun FavouriteArticleCard(
 ) {
     val context = LocalContext.current
 
-    // Determine the card background color based on the current theme (dark/light)
-    val cardBackgroundColor = if (isSystemInDarkTheme()) {
-        com.vpk.hackerfeed.ui.theme.GithubCardBackgroundDark
-    } else {
-        com.vpk.hackerfeed.ui.theme.GithubCardBackgroundLight
-    }
+    // Get the card background color using the reusable helper function
+    val cardBackgroundColor = getCardBackgroundColor()
     val cardContentColor = MaterialTheme.colorScheme.onSurface
 
     Card(

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesActivity.kt
@@ -125,7 +125,7 @@ fun FavouritesScreen(viewModel: FavouritesViewModel) {
                 CircularProgressIndicator()
             } else if (uiState.error != null) {
                 Text(
-                    text = uiState.error!!,
+                    text = uiState.error ?: "",
                     modifier = Modifier.padding(16.dp)
                 )
             } else if (uiState.favouriteArticles.isEmpty()) {

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesViewModel.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesViewModel.kt
@@ -1,0 +1,56 @@
+package com.vpk.hackerfeed
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.vpk.hackerfeed.database.AppDatabase
+import com.vpk.hackerfeed.database.FavouriteArticle
+import com.vpk.hackerfeed.repository.FavouritesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class FavouritesUiState(
+    val isLoading: Boolean = true,
+    val favouriteArticles: List<FavouriteArticle> = emptyList(),
+    val error: String? = null
+)
+
+class FavouritesViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val database = AppDatabase.getInstance(application)
+    private val favouritesRepository = FavouritesRepository(database.favouriteArticleDao())
+
+    private val _uiState = MutableStateFlow(FavouritesUiState())
+    val uiState: StateFlow<FavouritesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadFavourites()
+    }
+
+    private fun loadFavourites() {
+        viewModelScope.launch {
+            try {
+                favouritesRepository.getAllFavourites().collect { favourites ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        favouriteArticles = favourites,
+                        error = null
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    error = "Failed to load favourites: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun removeFromFavourites(articleId: Long) {
+        viewModelScope.launch {
+            favouritesRepository.removeFromFavourites(articleId)
+        }
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/FavouritesViewModel.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/FavouritesViewModel.kt
@@ -1,9 +1,7 @@
 package com.vpk.hackerfeed
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.vpk.hackerfeed.database.AppDatabase
 import com.vpk.hackerfeed.database.FavouriteArticle
 import com.vpk.hackerfeed.repository.FavouritesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,10 +15,9 @@ data class FavouritesUiState(
     val error: String? = null
 )
 
-class FavouritesViewModel(application: Application) : AndroidViewModel(application) {
-
-    private val database = AppDatabase.getInstance(application)
-    private val favouritesRepository = FavouritesRepository(database.favouriteArticleDao())
+class FavouritesViewModel(
+    private val favouritesRepository: FavouritesRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FavouritesUiState())
     val uiState: StateFlow<FavouritesUiState> = _uiState.asStateFlow()

--- a/app/src/main/java/com/vpk/hackerfeed/HackerFeedApplication.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/HackerFeedApplication.kt
@@ -1,0 +1,16 @@
+package com.vpk.hackerfeed
+
+import android.app.Application
+import com.vpk.hackerfeed.di.AppContainer
+import com.vpk.hackerfeed.di.DefaultAppContainer
+
+/**
+ * Custom Application class that provides the dependency injection container.
+ */
+class HackerFeedApplication : Application() {
+    
+    // Lazy initialization of the DI container
+    val container: AppContainer by lazy {
+        DefaultAppContainer(this)
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/MainActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/MainActivity.kt
@@ -51,13 +51,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vpk.hackerfeed.di.ViewModelFactory
 import com.vpk.hackerfeed.ui.theme.GithubDarkGray
 import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
 import com.vpk.hackerfeed.ui.theme.getCardBackgroundColor
 import com.vpk.hackerfeed.components.AnimatedFavoriteButton
 
 class MainActivity : ComponentActivity() {
-    private val viewModel: NewsViewModel by viewModels()
+    private val viewModel: NewsViewModel by viewModels {
+        ViewModelFactory((application as HackerFeedApplication).container)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/vpk/hackerfeed/MainActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/MainActivity.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -52,6 +53,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vpk.hackerfeed.ui.theme.GithubDarkGray
 import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
+import com.vpk.hackerfeed.components.AnimatedFavoriteButton
 
 class MainActivity : ComponentActivity() {
     private val viewModel: NewsViewModel by viewModels()
@@ -258,22 +260,11 @@ fun ArticleCard(
                                 color = MaterialTheme.colorScheme.secondary
                             )
                         }
-                        IconButton(
+                        AnimatedFavoriteButton(
+                            isFavourite = isFavourite,
                             onClick = onToggleFavourite,
                             modifier = Modifier.padding(start = 8.dp)
-                        ) {
-                            Icon(
-                                imageVector = if (isFavourite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-                                contentDescription = if (isFavourite) 
-                                    stringResource(R.string.remove_from_favourites) 
-                                else 
-                                    stringResource(R.string.add_to_favourites),
-                                tint = if (isFavourite) 
-                                    MaterialTheme.colorScheme.primary 
-                                else 
-                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                            )
-                        }
+                        )
                     }
                     if (article.url != null) {
                         Button(
@@ -354,6 +345,64 @@ fun ArticleCardInListPreview() {
                 onToggleFavourite = {},
                 modifier = Modifier.fillMaxWidth()
             )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Animated Favorite Button")
+@Composable
+fun AnimatedFavoriteButtonPreview() {
+    HackerFeedTheme {
+        Surface(modifier = Modifier.padding(24.dp)) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                Text(
+                    text = "Animated Favorite Button Demo",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(32.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        AnimatedFavoriteButton(
+                            isFavourite = false,
+                            onClick = { }
+                        )
+                        Text(
+                            text = "Add to Favourites",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+                    
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        AnimatedFavoriteButton(
+                            isFavourite = true,
+                            onClick = { }
+                        )
+                        Text(
+                            text = "Remove from Favourites",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+                }
+                
+                Text(
+                    text = "Tap the buttons to see the bounce animation!",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vpk/hackerfeed/MainActivity.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/MainActivity.kt
@@ -53,6 +53,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vpk.hackerfeed.ui.theme.GithubDarkGray
 import com.vpk.hackerfeed.ui.theme.HackerFeedTheme
+import com.vpk.hackerfeed.ui.theme.getCardBackgroundColor
 import com.vpk.hackerfeed.components.AnimatedFavoriteButton
 
 class MainActivity : ComponentActivity() {
@@ -207,12 +208,8 @@ fun ArticleCard(
 ) {
     val context = LocalContext.current
 
-    // Determine the card background color based on the current theme (dark/light)
-    val cardBackgroundColor = if (isSystemInDarkTheme()) {
-        com.vpk.hackerfeed.ui.theme.GithubCardBackgroundDark
-    } else {
-        com.vpk.hackerfeed.ui.theme.GithubCardBackgroundLight
-    }
+    // Get the card background color using the reusable helper function
+    val cardBackgroundColor = getCardBackgroundColor()
     val cardContentColor = MaterialTheme.colorScheme.onSurface
 
     Card(

--- a/app/src/main/java/com/vpk/hackerfeed/NewsViewModel.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/NewsViewModel.kt
@@ -1,9 +1,7 @@
 package com.vpk.hackerfeed
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.vpk.hackerfeed.database.AppDatabase
 import com.vpk.hackerfeed.repository.FavouritesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,10 +17,9 @@ data class NewsUiState(
     val error: String? = null
 )
 
-class NewsViewModel(application: Application) : AndroidViewModel(application) {
-
-    private val database = AppDatabase.getInstance(application)
-    private val favouritesRepository = FavouritesRepository(database.favouriteArticleDao())
+class NewsViewModel(
+    private val favouritesRepository: FavouritesRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(NewsUiState())
     val uiState: StateFlow<NewsUiState> = _uiState.asStateFlow()

--- a/app/src/main/java/com/vpk/hackerfeed/NewsViewModel.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/NewsViewModel.kt
@@ -3,6 +3,7 @@ package com.vpk.hackerfeed
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vpk.hackerfeed.repository.FavouritesRepository
+import com.vpk.hackerfeed.repository.NewsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,6 +19,7 @@ data class NewsUiState(
 )
 
 class NewsViewModel(
+    private val newsRepository: NewsRepository,
     private val favouritesRepository: FavouritesRepository
 ) : ViewModel() {
 
@@ -47,7 +49,7 @@ class NewsViewModel(
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
             try {
-                val ids = RetrofitInstance.api.getTopStoryIds()
+                val ids = newsRepository.getTopStoryIds()
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -77,7 +79,7 @@ class NewsViewModel(
 
         viewModelScope.launch {
             try {
-                val article = RetrofitInstance.api.getArticleDetails(id)
+                val article = newsRepository.getArticleDetails(id)
                 _uiState.update { currentState ->
                     val updatedArticles = currentState.articles.toMutableMap()
                     updatedArticles[id] = article

--- a/app/src/main/java/com/vpk/hackerfeed/NewsViewModel.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/NewsViewModel.kt
@@ -104,8 +104,4 @@ class NewsViewModel(application: Application) : AndroidViewModel(application) {
             favouritesRepository.toggleFavourite(article)
         }
     }
-
-    fun isArticleFavourite(articleId: Long): Boolean {
-        return _uiState.value.favouriteArticleIds.contains(articleId)
-    }
 }

--- a/app/src/main/java/com/vpk/hackerfeed/components/AnimatedFavoriteButton.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/components/AnimatedFavoriteButton.kt
@@ -1,0 +1,86 @@
+package com.vpk.hackerfeed.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
+import com.vpk.hackerfeed.R
+import kotlinx.coroutines.launch
+
+@Composable
+fun AnimatedFavoriteButton(
+    isFavourite: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scale = remember { Animatable(1f) }
+    val coroutineScope = rememberCoroutineScope()
+    
+    // Animated color transition
+    val iconColor by animateColorAsState(
+        targetValue = if (isFavourite) 
+            MaterialTheme.colorScheme.primary 
+        else 
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+        animationSpec = tween(durationMillis = 200),
+        label = "favorite_color_animation"
+    )
+
+    IconButton(
+        onClick = {
+            // Trigger the bounce animation
+            coroutineScope.launch {
+                // Scale down
+                scale.animateTo(
+                    targetValue = 0.7f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessHigh
+                    )
+                )
+                // Scale up with bounce
+                scale.animateTo(
+                    targetValue = 1.3f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessMedium
+                    )
+                )
+                // Return to normal size
+                scale.animateTo(
+                    targetValue = 1f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessMedium
+                    )
+                )
+            }
+            onClick()
+        },
+        modifier = modifier
+    ) {
+        Icon(
+            imageVector = if (isFavourite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+            contentDescription = if (isFavourite) 
+                stringResource(R.string.remove_from_favourites) 
+            else 
+                stringResource(R.string.add_to_favourites),
+            tint = iconColor,
+            modifier = Modifier.scale(scale.value)
+        )
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/database/AppDatabase.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/AppDatabase.kt
@@ -1,0 +1,32 @@
+package com.vpk.hackerfeed.database
+
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import android.content.Context
+
+@Database(
+    entities = [FavouriteArticle::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun favouriteArticleDao(): FavouriteArticleDao
+    
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+        
+        fun getInstance(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "hackerfeed_database"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/database/AppDatabase.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/AppDatabase.kt
@@ -8,7 +8,7 @@ import android.content.Context
 @Database(
     entities = [FavouriteArticle::class],
     version = 1,
-    exportSchema = false
+    exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun favouriteArticleDao(): FavouriteArticleDao

--- a/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticle.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticle.kt
@@ -1,0 +1,15 @@
+package com.vpk.hackerfeed.database
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favourite_articles")
+data class FavouriteArticle(
+    @PrimaryKey val id: Long,
+    val title: String?,
+    val author: String?,
+    val score: Int?,
+    val time: Long?,
+    val url: String?,
+    val dateAdded: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticleDao.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticleDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -27,4 +28,13 @@ interface FavouriteArticleDao {
     
     @Delete
     suspend fun deleteFavourite(article: FavouriteArticle)
+    
+    @Transaction
+    suspend fun toggle(article: FavouriteArticle) {
+        if (isFavourite(article.id)) {
+            deleteFavouriteById(article.id)
+        } else {
+            insertFavourite(article)
+        }
+    }
 }

--- a/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticleDao.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticleDao.kt
@@ -1,0 +1,30 @@
+package com.vpk.hackerfeed.database
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavouriteArticleDao {
+    
+    @Query("SELECT * FROM favourite_articles ORDER BY dateAdded DESC")
+    fun getAllFavourites(): Flow<List<FavouriteArticle>>
+    
+    @Query("SELECT * FROM favourite_articles WHERE id = :id")
+    suspend fun getFavouriteById(id: Long): FavouriteArticle?
+    
+    @Query("SELECT EXISTS(SELECT 1 FROM favourite_articles WHERE id = :id)")
+    suspend fun isFavourite(id: Long): Boolean
+    
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertFavourite(article: FavouriteArticle)
+    
+    @Query("DELETE FROM favourite_articles WHERE id = :id")
+    suspend fun deleteFavouriteById(id: Long)
+    
+    @Delete
+    suspend fun deleteFavourite(article: FavouriteArticle)
+}

--- a/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticleDao.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/FavouriteArticleDao.kt
@@ -26,9 +26,6 @@ interface FavouriteArticleDao {
     @Query("DELETE FROM favourite_articles WHERE id = :id")
     suspend fun deleteFavouriteById(id: Long)
     
-    @Delete
-    suspend fun deleteFavourite(article: FavouriteArticle)
-    
     @Transaction
     suspend fun toggle(article: FavouriteArticle) {
         if (isFavourite(article.id)) {

--- a/app/src/main/java/com/vpk/hackerfeed/di/AppContainer.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/di/AppContainer.kt
@@ -1,8 +1,10 @@
 package com.vpk.hackerfeed.di
 
 import android.app.Application
+import com.vpk.hackerfeed.RetrofitInstance
 import com.vpk.hackerfeed.database.AppDatabase
 import com.vpk.hackerfeed.repository.FavouritesRepository
+import com.vpk.hackerfeed.repository.NewsRepository
 
 /**
  * Manual dependency injection container for the application.
@@ -10,6 +12,7 @@ import com.vpk.hackerfeed.repository.FavouritesRepository
  */
 interface AppContainer {
     val favouritesRepository: FavouritesRepository
+    val newsRepository: NewsRepository
 }
 
 /**
@@ -25,5 +28,9 @@ class DefaultAppContainer(
     
     override val favouritesRepository: FavouritesRepository by lazy {
         FavouritesRepository(database.favouriteArticleDao())
+    }
+    
+    override val newsRepository: NewsRepository by lazy {
+        NewsRepository(RetrofitInstance.api)
     }
 }

--- a/app/src/main/java/com/vpk/hackerfeed/di/AppContainer.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/di/AppContainer.kt
@@ -1,0 +1,29 @@
+package com.vpk.hackerfeed.di
+
+import android.app.Application
+import com.vpk.hackerfeed.database.AppDatabase
+import com.vpk.hackerfeed.repository.FavouritesRepository
+
+/**
+ * Manual dependency injection container for the application.
+ * This provides dependencies to ViewModels and other components.
+ */
+interface AppContainer {
+    val favouritesRepository: FavouritesRepository
+}
+
+/**
+ * Default implementation of AppContainer that provides real dependencies.
+ */
+class DefaultAppContainer(
+    private val application: Application
+) : AppContainer {
+    
+    private val database: AppDatabase by lazy {
+        AppDatabase.getInstance(application)
+    }
+    
+    override val favouritesRepository: FavouritesRepository by lazy {
+        FavouritesRepository(database.favouriteArticleDao())
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/di/ViewModelFactory.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/di/ViewModelFactory.kt
@@ -16,7 +16,10 @@ class ViewModelFactory(
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return when (modelClass) {
             NewsViewModel::class.java -> {
-                NewsViewModel(container.favouritesRepository) as T
+                NewsViewModel(
+                    container.newsRepository,
+                    container.favouritesRepository
+                ) as T
             }
             FavouritesViewModel::class.java -> {
                 FavouritesViewModel(container.favouritesRepository) as T

--- a/app/src/main/java/com/vpk/hackerfeed/di/ViewModelFactory.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/di/ViewModelFactory.kt
@@ -1,0 +1,27 @@
+package com.vpk.hackerfeed.di
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.vpk.hackerfeed.FavouritesViewModel
+import com.vpk.hackerfeed.NewsViewModel
+
+/**
+ * Custom ViewModelFactory that uses dependency injection container to provide dependencies.
+ */
+class ViewModelFactory(
+    private val container: AppContainer
+) : ViewModelProvider.Factory {
+    
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return when (modelClass) {
+            NewsViewModel::class.java -> {
+                NewsViewModel(container.favouritesRepository) as T
+            }
+            FavouritesViewModel::class.java -> {
+                FavouritesViewModel(container.favouritesRepository) as T
+            }
+            else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+        }
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/repository/FavouritesRepository.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/repository/FavouritesRepository.kt
@@ -28,10 +28,14 @@ class FavouritesRepository(private val dao: FavouriteArticleDao) {
     }
     
     suspend fun toggleFavourite(article: Article) {
-        if (isFavourite(article.id)) {
-            removeFromFavourites(article.id)
-        } else {
-            addToFavourites(article)
-        }
+        val favouriteArticle = FavouriteArticle(
+            id = article.id,
+            title = article.title,
+            author = article.author,
+            score = article.score,
+            time = article.time,
+            url = article.url
+        )
+        dao.toggle(favouriteArticle)
     }
 }

--- a/app/src/main/java/com/vpk/hackerfeed/repository/FavouritesRepository.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/repository/FavouritesRepository.kt
@@ -1,0 +1,37 @@
+package com.vpk.hackerfeed.repository
+
+import com.vpk.hackerfeed.Article
+import com.vpk.hackerfeed.database.FavouriteArticle
+import com.vpk.hackerfeed.database.FavouriteArticleDao
+import kotlinx.coroutines.flow.Flow
+
+class FavouritesRepository(private val dao: FavouriteArticleDao) {
+    
+    fun getAllFavourites(): Flow<List<FavouriteArticle>> = dao.getAllFavourites()
+    
+    suspend fun isFavourite(articleId: Long): Boolean = dao.isFavourite(articleId)
+    
+    suspend fun addToFavourites(article: Article) {
+        val favouriteArticle = FavouriteArticle(
+            id = article.id,
+            title = article.title,
+            author = article.author,
+            score = article.score,
+            time = article.time,
+            url = article.url
+        )
+        dao.insertFavourite(favouriteArticle)
+    }
+    
+    suspend fun removeFromFavourites(articleId: Long) {
+        dao.deleteFavouriteById(articleId)
+    }
+    
+    suspend fun toggleFavourite(article: Article) {
+        if (isFavourite(article.id)) {
+            removeFromFavourites(article.id)
+        } else {
+            addToFavourites(article)
+        }
+    }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/repository/NewsRepository.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/repository/NewsRepository.kt
@@ -1,0 +1,11 @@
+package com.vpk.hackerfeed.repository
+
+import com.vpk.hackerfeed.Article
+import com.vpk.hackerfeed.HackerNewsApiService
+
+class NewsRepository(private val apiService: HackerNewsApiService) {
+    
+    suspend fun getTopStoryIds(): List<Long> = apiService.getTopStoryIds()
+    
+    suspend fun getArticleDetails(id: Long): Article = apiService.getArticleDetails(id)
+}

--- a/app/src/main/java/com/vpk/hackerfeed/ui/theme/Theme.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/ui/theme/Theme.kt
@@ -110,3 +110,16 @@ fun HackerFeedTheme(
         content = content
     )
 }
+
+/**
+ * Returns the appropriate card background color based on the current theme (dark/light).
+ * This helper function eliminates code duplication across different activities.
+ */
+@Composable
+fun getCardBackgroundColor(): Color {
+    return if (isSystemInDarkTheme()) {
+        GithubCardBackgroundDark
+    } else {
+        GithubCardBackgroundLight
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,9 @@
     <string name="about_hackerfeed_title" />
     <string name="navigate_back_content_desc">Back</string>
     <string name="about">About</string>
+    <string name="favourites_title">Favourites</string>
+    <string name="add_to_favourites">Add to favourites</string>
+    <string name="remove_from_favourites">Remove from favourites</string>
+    <string name="no_favourites">No favourites yet</string>
+    <string name="no_favourites_description">Tap the heart icon on any article to add it to your favourites</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ material3 = "1.3.2"
 material3Adaptive = "1.0.0-alpha06"
 materialIconsExtended = "1.7.8"
 retrofit = "2.11.0"
+room = "2.6.1"
+ksp = "2.0.21-1.0.27"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,9 +37,13 @@ androidx-compose-foundation = { group = "androidx.compose.foundation", name = "f
 material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
* **Favourite News Feature**: Implemented a 'Favourite News' feature, allowing users to save articles locally using the Room Persistence Library for persistent storage.
* **Dedicated Favourites Screen**: Introduced a new `FavouritesActivity` with a Jetpack Compose UI to display and manage all saved articles, including options to view the full article and remove from favourites.
* **Main Feed Integration**: Integrated favourite/unfavourite functionality directly into the `MainActivity`'s article cards, providing a seamless user experience for adding or removing articles from the main news feed.
* **Data Layer Architecture**: Established a robust data layer for the favourites feature, including new `FavouritesViewModel`, `FavouritesRepository`, and Room DAO/Entities (`AppDatabase`, `FavouriteArticle`, `FavouriteArticleDao`) for clean separation of concerns and efficient data management.
* **Build System Updates**: Upgraded the project's Java source/target compatibility and JVM target versions to 21, and incorporated the Kotlin Symbol Processing (KSP) plugin for annotation processing, aligning with modern Android development practices.