### PR TITLE
add: room schemas

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.androidx.room)
 }
 
 android {
@@ -39,6 +40,10 @@ android {
     buildFeatures {
         compose = true
     }
+}
+
+room {
+    schemaDirectory("$projectDir/schemas")
 }
 
 dependencies {

--- a/app/schemas/com.vpk.hackerfeed.database.AppDatabase/2.json
+++ b/app/schemas/com.vpk.hackerfeed.database.AppDatabase/2.json
@@ -1,0 +1,141 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "9b779dccf10b93e432a60a8c5af75071",
+    "entities": [
+      {
+        "tableName": "favourite_articles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT, `author` TEXT, `score` INTEGER, `time` INTEGER, `url` TEXT, `dateAdded` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "dateAdded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_articles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `author` TEXT, `score` INTEGER, `time` INTEGER, `title` TEXT, `url` TEXT, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_top_stories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `storyIds` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storyIds",
+            "columnName": "storyIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9b779dccf10b93e432a60a8c5af75071')"
+    ]
+  }
+}

--- a/app/src/main/java/com/vpk/hackerfeed/database/AppDatabase.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/AppDatabase.kt
@@ -3,6 +3,7 @@ package com.vpk.hackerfeed.database
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import android.content.Context
@@ -16,6 +17,7 @@ import android.content.Context
     version = 2,
     exportSchema = true
 )
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun favouriteArticleDao(): FavouriteArticleDao
     abstract fun cachedArticleDao(): CachedArticleDao

--- a/app/src/main/java/com/vpk/hackerfeed/database/CachedTopStories.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/CachedTopStories.kt
@@ -11,6 +11,6 @@ import androidx.room.PrimaryKey
 data class CachedTopStories(
     @PrimaryKey
     val id: Int = 1, // Single row table
-    val storyIds: String, // JSON string of story IDs
+    val storyIds: List<Long>, // List of story IDs
     val cachedAt: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/vpk/hackerfeed/database/Converters.kt
+++ b/app/src/main/java/com/vpk/hackerfeed/database/Converters.kt
@@ -1,0 +1,27 @@
+package com.vpk.hackerfeed.database
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/**
+ * Type converters for Room database.
+ * Handles conversion between complex types and database-compatible types.
+ */
+class Converters {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromString(value: String?): List<Long>? {
+        if (value == null) {
+            return null
+        }
+        val listType = object : TypeToken<List<Long>>() {}.type
+        return gson.fromJson(value, listType)
+    }
+
+    @TypeConverter
+    fun fromList(list: List<Long>?): String? {
+        return if (list == null) null else gson.toJson(list)
+    }
+}

--- a/app/src/test/java/com/vpk/hackerfeed/database/ConvertersTest.kt
+++ b/app/src/test/java/com/vpk/hackerfeed/database/ConvertersTest.kt
@@ -1,0 +1,100 @@
+package com.vpk.hackerfeed.database
+
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Unit tests for the Converters class.
+ */
+class ConvertersTest {
+
+    private val converters = Converters()
+
+    @Test
+    fun `fromList converts List to JSON string correctly`() {
+        // Arrange
+        val storyIds = listOf(1L, 2L, 3L, 4L, 5L)
+        
+        // Act
+        val result = converters.fromList(storyIds)
+        
+        // Assert
+        assertNotNull(result)
+        assertTrue(result!!.contains("1"))
+        assertTrue(result.contains("2"))
+        assertTrue(result.contains("3"))
+        assertTrue(result.contains("4"))
+        assertTrue(result.contains("5"))
+    }
+
+    @Test
+    fun `fromString converts JSON string to List correctly`() {
+        // Arrange
+        val jsonString = "[1,2,3,4,5]"
+        val expectedList = listOf(1L, 2L, 3L, 4L, 5L)
+        
+        // Act
+        val result = converters.fromString(jsonString)
+        
+        // Assert
+        assertNotNull(result)
+        assertEquals(expectedList, result)
+    }
+
+    @Test
+    fun `fromList handles null input`() {
+        // Act
+        val result = converters.fromList(null)
+        
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `fromString handles null input`() {
+        // Act
+        val result = converters.fromString(null)
+        
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `roundtrip conversion preserves data`() {
+        // Arrange
+        val originalList = listOf(123L, 456L, 789L, 1000L, 2000L)
+        
+        // Act
+        val jsonString = converters.fromList(originalList)
+        val convertedList = converters.fromString(jsonString)
+        
+        // Assert
+        assertEquals(originalList, convertedList)
+    }
+
+    @Test
+    fun `fromString handles empty list JSON`() {
+        // Arrange
+        val emptyListJson = "[]"
+        
+        // Act
+        val result = converters.fromString(emptyListJson)
+        
+        // Assert
+        assertNotNull(result)
+        assertTrue(result!!.isEmpty())
+    }
+
+    @Test
+    fun `fromList handles empty list`() {
+        // Arrange
+        val emptyList = emptyList<Long>()
+        
+        // Act
+        val result = converters.fromList(emptyList)
+        
+        // Assert
+        assertNotNull(result)
+        assertEquals("[]", result)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,4 +52,5 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+androidx-room = { id = "androidx.room", version.ref = "room" }
 


### PR DESCRIPTION
* **Room Plugin Integration**: Integrated the Android Room Gradle plugin into `app/build.gradle.kts` by adding `alias(libs.plugins.androidx.room)` to the `plugins` block. This enables Room's capabilities for database management and schema generation.
* **Schema Directory Configuration**: Configured the Room plugin in `app/build.gradle.kts` to output database schemas to the `$projectDir/schemas` directory. This ensures that the database schema is version-controlled and available for migrations.
* **Initial Database Schema Definition**: Added the version 2 schema for `AppDatabase` as `app/schemas/com.vpk.hackerfeed.database.AppDatabase/2.json`. This JSON file details the structure of three tables: `favourite_articles`, `cached_articles`, and `cached_top_stories`, including their respective columns, data types, and primary keys.
* **Gradle Plugin Alias**: Defined the `androidx-room` plugin alias in `gradle/libs.versions.toml`, linking it to the `androidx.room` plugin and its version reference.